### PR TITLE
Update Helpers.cs

### DIFF
--- a/Nue/Nue.Core/Helpers.cs
+++ b/Nue/Nue.Core/Helpers.cs
@@ -145,7 +145,7 @@ namespace Nue.Core
 
         private static string GetWinningFolder(string[] folders, Regex regex)
         {
-            var folderAssociations = new Dictionary<string, double>();
+            var folderAssociations = new Dictionary<string, string>();
             foreach (var folder in folders)
             {
                 var exactFolderName = Path.GetFileName(folder);
@@ -155,11 +155,11 @@ namespace Nue.Core
 
                 if (!string.IsNullOrEmpty(folderVersion))
                 {
-                    folderAssociations.Add(folder, double.Parse(folderVersion));
+                    folderAssociations.Add(folder, folderVersion);
                 }
                 else
                 {
-                    folderAssociations.Add(folder, 0);
+                    folderAssociations.Add(folder, "0");
                 }
             }
 


### PR DESCRIPTION
Today, the version for the dependency folder is registered as a double. This causes an issue, where the double can be incorrectly parsed for situations where the TFM is not structured as a double. This change moves away from assignment to double and replaces that with a string container.